### PR TITLE
add types for sazerac

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "browser": "dist/sazerac.js",
   "main": "lib/main.js",
+  "typings": "types/main.d.ts",
   "files": [
     "dist",
     "lib",

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,0 +1,9 @@
+export class TestCase {
+  expect(returnValue): this
+  describe(message: string): this
+  should(message: string): this
+  assert(message: string, assertFunction: (actualReturnValue: any) => void): this
+}
+
+export function test(testFn: Function, definerFn: Function): void
+export function given(...args: any[]): TestCase


### PR DESCRIPTION
for typescript

tested that it compiles with:

```ts
import { test, given } from 'sazerac'

function sum(a: number, b: number): number {
  return a + b
}

test(sum, () => {
  given(1, 2).expect(3)
})
```