### PR TITLE
Move variable caching for frameworks in main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "init": "eslint --init",
     "lint": "eslint src test",
     "test": "BABEL_ENV=test mocha --compilers js:babel-core/register --recursive",
+    "test:watch": "BABEL_ENV=test mocha --watch --watch-extensions js --compilers js:babel-core/register --recursive",
     "check": "npm run lint && npm run test",
     "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=dev webpack src/main.js dist/sazerac.js",

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,6 @@ import describer from './describer'
 import { newTestCase } from './testCase'
 import { newTestCaseCollection } from './testCaseCollection'
 
-const frameworkFns = {
-  describeFn: describe,
-  itFn: it
-}
-
 let _state
 
 listener((state) => { _state = state })
@@ -22,6 +17,10 @@ listener((state) => { _state = state })
  * @param {function} definerFn - The function that defines test cases for `testFn`
  */
 const test = (testFn, definerFn) => {
+  const frameworkFns = {
+    describeFn: describe,
+    itFn: it
+  }
   if (!isFunction(testFn)) throw new Error(errors.expectedFunction('test', testFn))
   if (!isFunction(definerFn)) throw new Error(errors.expectedFunction('test', definerFn))
   actions.init({ testFn })


### PR DESCRIPTION
When the method `test` is run through multiple test cycles produced from `mocha --watch`, the later calls to `test` method seem to never attach to a test from mocha. 

The first test will run fine. In later tests the `describer` is no longer attaching the tests to correct `describe` and `it` from the test framework.
This solves the issue by re-finding the 'describe' per `test` function.