### PR TITLE
Work with `noImplicitAny` ts compiler option

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,5 +1,5 @@
 export class TestCase {
-  expect(returnValue): this
+  expect(returnValue: any): this
   describe(message: string): this
   should(message: string): this
   assert(message: string, assertFunction: (actualReturnValue: any) => void): this


### PR DESCRIPTION
If the TypeScript compiler is set to `strict` or has `noImplicitAny` this will cause a project not to compile