### PR TITLE
Fix formatted should() message

### DIFF
--- a/src/reducers/cases.js
+++ b/src/reducers/cases.js
@@ -33,7 +33,7 @@ const getCaseProp = (state, caseIndex, prop) => {
 export default (state = [], action) => {
 
   const { caseIndex } = action
-  let inputParams, args, expectedVal, msg
+  let inputParams, args, expectation, msg
   const defaultMsgFns = {
     [expectationTypes.VALUE]: defaultShouldMessage,
     [expectationTypes.ERROR]: defaultShouldThrowMessage
@@ -66,9 +66,9 @@ export default (state = [], action) => {
       return setCaseProps(state, caseIndex, { describeMessage: msg })
 
     case actionTypes.SET_CASE_SHOULD_MESSAGE:
-      expectedVal = getCaseProp(state, caseIndex, 'expectedValue')
-      msg = !isUndefined(expectedVal) ?
-                    vsprintf(action.message, [expectedVal]) : action.message
+      expectation = getCaseProp(state, caseIndex, 'expectation')
+      msg = expectation !== undefined && expectationTypes.VALUE in expectation ?
+                    vsprintf(action.message, [expectation[expectationTypes.VALUE]]) : action.message
       return setCaseProps(state, caseIndex, { shouldMessage: msg })
 
     case actionTypes.INIT:

--- a/test/unit/reducers/cases_spec.js
+++ b/test/unit/reducers/cases_spec.js
@@ -276,14 +276,14 @@ runTests([
     ],
 
     [
-      'when given a formatted action.message and a case with expectedValue',
+      'when given a formatted action.message and a case with an expected value',
       [
-        [ { expectedValue: 'mock_val' } ],
+        [ { expectation: { [expectationTypes.VALUE]: 'mock_val' } } ],
         { type: 'SET_CASE_SHOULD_MESSAGE', caseIndex: 0, message: 'should return %s' }
       ],
       [
         [
-          'should return cases with shouldMessage formatted with expectedValue',
+          'should return cases with shouldMessage formatted with the expected value',
           (cases) => {
             assert.deepPropertyVal(cases, '[0].shouldMessage', 'should return mock_val')
           }
@@ -292,7 +292,7 @@ runTests([
     ],
 
     [
-      'when given a formatted action.message and a case without expectedValue',
+      'when given a formatted action.message and a case without expected value',
       [
         [ { } ],
         { type: 'SET_CASE_SHOULD_MESSAGE', caseIndex: 0, message: 'should return %s' }


### PR DESCRIPTION
Formatted `should()` messages do not work. When I run `.should("return '%s', for parity with coveragePercentage()"` I expect to see a string formatted with the expected value, but instead I see the raw format string.

The bug emerged because the spec tests mock the actions and the reducer tests are testing only one action at a time. When the state schema subsequently changed, the functionality broke but its tests passed. There's no place to put a test that relies on the side effect of the first, and uses it in the second.

The surest way to prevent this would be a test which invokes `given().expect().should()` and examining the message.

Though another approach would be to use a schema validation library to validate the state upon entering and exiting the reducer. When the schema was changed, it would have triggered failures in these tests.

I've taken this approach before when I wanted to document the state schema, because it ensures the schema stays in sync with the code. If you'd like a PR for that, let me know!