### PR TITLE
Include TypeScript types in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "files": [
     "dist",
     "lib",
-    "src"
+    "src",
+    "types"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
When including this package, the type definitions file is unavailable because it was not included in `package.json`.

The expected behavior is to have the directory `/types` included in the downloaded package.

https://unpkg.com/sazerac@0.4.2/
