### PR TITLE
Adding name in define for require.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ var config = {
   },
   output: {
     library: 'Sazerac',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
   plugins: []
 }


### PR DESCRIPTION
Without this modification, the file created by webpack is not recognized as valid by require.js (giving the following error: "Error: Mismatched anonymous define() module").

With the modification generated dist files can be used in rrequire.js.